### PR TITLE
Disabling csrf and adding CORS permission to same_origin access

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -11,3 +11,4 @@ flake8==3.5.0
 coveralls
 coverage
 psycopg2-binary
+django-cors-headers

--- a/src/comex_stat/settings.py
+++ b/src/comex_stat/settings.py
@@ -39,6 +39,7 @@ INSTALLED_APPS = [
     'django.contrib.staticfiles',
     'comex_stat.assets',
     'graphene_django',
+    'corsheaders',
 ]
 
 GRAPHENE = {
@@ -46,18 +47,22 @@ GRAPHENE = {
 }
 
 FIXTURE_DIRS = (
-   'assets/fixtures/',
+    'assets/fixtures/',
 )
 
 MIDDLEWARE = [
     'django.middleware.security.SecurityMiddleware',
     'django.contrib.sessions.middleware.SessionMiddleware',
     'django.middleware.common.CommonMiddleware',
-    'django.middleware.csrf.CsrfViewMiddleware',
+    # 'django.middleware.csrf.CsrfViewMiddleware',
+    'corsheaders.middleware.CorsMiddleware',
     'django.contrib.auth.middleware.AuthenticationMiddleware',
     'django.contrib.messages.middleware.MessageMiddleware',
     'django.middleware.clickjacking.XFrameOptionsMiddleware',
 ]
+
+CORS_ORIGIN_ALLOW_ALL = True
+CORS_ALLOW_CREDENTIALS = True
 
 ROOT_URLCONF = 'comex_stat.urls'
 


### PR DESCRIPTION
Signed-off-by: Marcos Nery <marcosnery.comp@gmail.com>

# Descrição

Desabilitação temporaria do midware CSRF do Django e adição do CORS para possibilitar o acesso ao endpoint da API em GraphQL por meio do front-end em Angular, que em ambiente de desenvolvimento se encontra na mesma origem, sendo essa o localhost.


# Issue Relacionada

fixes #143 

# Tipo de Mudanças

- [ ] História de Usuário
- [ ] Historia Técnica

# Responsáveis pela revisão

@Joranhezon 

# Checklist

- [x] Os commits seguem o padrão de estilo desse projeto.
- [x] A branch está conforme nossa política.
- [ ] Houve sucesso na integração continua.
- [x] Os critérios de aceitação foram cumpridos.
- [x] Foram realizados testes (sendo o caso) que cobrem as funcionalidades entregues.
